### PR TITLE
Disable Python and pytest caches

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -q
+addopts = -q -p no:cacheprovider
 testpaths = tests
 
 [flake8]

--- a/src/sitecustomize.py
+++ b/src/sitecustomize.py
@@ -1,0 +1,31 @@
+"""Project-wide Python runtime configuration.
+
+This module is imported automatically when the Python interpreter starts.
+It disables creation of Python bytecode caches and removes any
+``__pycache__`` directories that might be created during execution.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# Prevent the interpreter from writing ``.pyc`` files.
+os.environ.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+sys.dont_write_bytecode = True
+
+# Repository root directory (``src`` is the parent of ``sitecustomize.py``).
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cleanup_pycache() -> None:
+    """Delete all ``__pycache__`` directories under the project root."""
+
+    for path in _ROOT.rglob("__pycache__"):
+        shutil.rmtree(path, ignore_errors=True)
+
+
+atexit.register(_cleanup_pycache)


### PR DESCRIPTION
## Summary
- Prevent pytest from creating `.pytest_cache` by disabling the cache provider.
- Add a startup hook that suppresses `.pyc` bytecode generation and removes any `__pycache__` directories on exit.

## Testing
- `pytest`
- `find . -name '__pycache__' -o -name '.pytest_cache'`

------
https://chatgpt.com/codex/tasks/task_e_689f2ceb602c832087228ca4dfd9209f