### PR TITLE
Improve documentation and Bouzidi visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,26 @@ Bouzidi link-fraction calculations for the D2Q9 model.
 
 ## Features
 
-- Parametric shapes: circle, ellipse, rectangle, rounded rectangle, Cassini oval
-- Boolean composition: union, intersection, difference
-- Accurate signed distance functions for voxelization and boundary location
-- Bouzidi interpolated boundary link-fraction calculation for D2Q9
-- I/O helpers for saving/loading `.npz` geometry datasets
-- Visualization utilities for solid masks, φ field, and Bouzidi diagnostics
+**lb2dgeom** covers the entire workflow of preparing complex 2‑D boundaries for
+LBM solvers:
+
+* **Parametric shapes** – circle, ellipse, rectangle (axis aligned or rotated),
+  rounded rectangle and Cassini oval.
+* **Boolean operations** – union, intersection and difference are implemented
+  using standard signed–distance blending rules.
+* **Signed distance fields** – shapes provide analytic ``sdf(x, y)`` methods and
+  are rasterised onto uniform Cartesian grids.
+* **Bouzidi boundary fractions** – compute ``q_i`` link fractions for all
+  D2Q9 lattice directions with physical length normalisation.
+* **I/O helpers** – save and load geometry data sets in ``.npz`` format.
+* **Visualisation utilities** – plot solid masks, signed distance fields,
+  Bouzidi histograms and per‑direction ``q_i`` fields.
 
 ## Installation
 
 ### Conda environment
 
-Create and activate the conda environment specified in `environment.yml`:
+Create and activate the conda environment specified in ``environment.yml``:
 
 ```bash
 conda env create -f environment.yml
@@ -26,30 +34,66 @@ conda activate lb2dgeom
 
 ### Editable install
 
-If you prefer a manual install, run:
+For a lightweight development install simply run:
 
 ```bash
 pip install -e .
 ```
 
-## Usage
+## Quickstart
+
+The snippet below demonstrates the typical work flow: build a grid, define a
+shape, rasterise its signed distance field, compute Bouzidi coefficients and
+produce diagnostic plots.
 
 ```python
+import numpy as np
+from lb2dgeom.bouzidi import compute_bouzidi
 from lb2dgeom.grids import Grid
-from lb2dgeom.shapes.circle import Circle
+from lb2dgeom.io import save_npz
 from lb2dgeom.raster import rasterize
+from lb2dgeom.shapes.circle import Circle
+from lb2dgeom import viz
 
-grid = Grid(nx=100, ny=100, dx=1.0, origin=(-50.0, -50.0))
-shape = Circle(0.0, 0.0, 20.0)
-phi, solid = rasterize(grid, shape)
+# Grid and shape
+g = Grid(nx=100, ny=80, dx=1.0, origin=(-50.0, -40.0))
+shape = Circle(x0=0.0, y0=0.0, r=20.0)
+
+# Rasterise and compute Bouzidi q_i
+phi, solid = rasterize(g, shape)
+bouzidi = compute_bouzidi(g, phi, solid)
+
+# Save and plot
+save_npz("circle_geom.npz", solid, phi, bouzidi)
+viz.plot_phi(phi, "circle_phi.png")
+viz.plot_bouzidi_dirs(bouzidi, "circle_bouzidi_dir")
 ```
 
-See the `examples/` directory for complete scripts including Bouzidi
-coefficients, file I/O, and plotting utilities.
+See the ``examples/`` directory for complete scripts for an ellipse and a
+Cassini oval. Running an example (e.g. ``python examples/demo_cassini.py``)
+produces geometry files and PNG diagnostics in ``examples/output/``.
+
+### Feature guide
+
+* **Grid generation** – ``Grid(nx, ny, dx, origin)`` provides cell centres and
+  spacing in physical units.
+* **Shapes** – analytic ``sdf`` implementations live in ``lb2dgeom.shapes`` and
+  share a common ``Shape`` base class. Shapes may be combined via boolean
+  operations from ``lb2dgeom.shapes.ops``.
+* **Rasterisation** – ``rasterize(grid, shape)`` samples ``phi`` and returns the
+  solid mask for LBM nodes.
+* **Bouzidi coefficients** – ``compute_bouzidi`` locates boundary intersections
+  for all lattice directions and returns an array of ``q_i`` fractions with
+  ``NaN`` in cells without solid neighbours.
+* **I/O** – ``lb2dgeom.io.save_npz`` and ``load_npz`` persist geometry arrays to
+  disk.
+* **Visualisation** – ``lb2dgeom.viz`` contains
+  ``plot_solid``, ``plot_phi``, ``plot_bouzidi_hist`` and
+  ``plot_bouzidi_dirs`` for inspecting geometry and boundary data.
 
 ## Running tests
 
-After installing the package, execute:
+After installing the package, run the test-suite to verify the installation:
 
 ```bash
 pytest -q

--- a/examples/demo_cassini.py
+++ b/examples/demo_cassini.py
@@ -1,1 +1,38 @@
-# Example: cassini oval shape
+"""Cassini oval demonstration script."""
+
+import os
+import numpy as np
+
+from lb2dgeom import viz
+from lb2dgeom.bouzidi import compute_bouzidi
+from lb2dgeom.grids import Grid
+from lb2dgeom.io import save_npz
+from lb2dgeom.raster import rasterize
+from lb2dgeom.shapes.cassini_oval import CassiniOval
+
+
+if __name__ == "__main__":
+    # Grid setup
+    g = Grid(nx=120, ny=120, dx=1.0, origin=(-60.0, -60.0))
+
+    # Define a rotated Cassini oval
+    shape = CassiniOval(x0=0.0, y0=0.0, a=25.0, c=15.0, theta=np.pi / 4)
+
+    # Rasterize
+    phi, solid = rasterize(g, shape)
+
+    # Bouzidi coefficients
+    bouzidi = compute_bouzidi(g, phi, solid)
+
+    # Save arrays
+    out_dir = os.path.join("examples", "output")
+    os.makedirs(out_dir, exist_ok=True)
+    save_npz(os.path.join(out_dir, "cassini_geom.npz"), solid, phi, bouzidi)
+
+    # Diagnostics
+    viz.plot_solid(solid, "cassini_solid.png", show=False)
+    viz.plot_phi(phi, "cassini_phi.png", levels=30, show=False)
+    viz.plot_bouzidi_hist(bouzidi, "cassini_bouzidi_hist.png", show=False)
+    viz.plot_bouzidi_dirs(bouzidi, "cassini_bouzidi_dir", show=False)
+
+    print("Demo Cassini oval complete. Outputs saved in examples/output/")

--- a/src/lb2dgeom/viz.py
+++ b/src/lb2dgeom/viz.py
@@ -1,12 +1,18 @@
+"""Visualization utilities for geometry and Bouzidi diagnostics."""
+
 import os
-import numpy as np
-import matplotlib.pyplot as plt
 from typing import Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import colors
+
 
 def _ensure_output_dir():
     out_dir = os.path.join("examples", "output")
     os.makedirs(out_dir, exist_ok=True)
     return out_dir
+
 
 def plot_solid(solid: np.ndarray, fname: str, show: bool = False) -> None:
     """Plot solid mask."""
@@ -21,13 +27,31 @@ def plot_solid(solid: np.ndarray, fname: str, show: bool = False) -> None:
         plt.show()
     plt.close()
 
-def plot_phi(phi: np.ndarray, fname: str, levels: Optional[int] = 20, show: bool = False) -> None:
-    """Plot signed distance field with contours."""
+
+def plot_phi(
+    phi: np.ndarray, fname: str, levels: Optional[int] = 20, show: bool = False
+) -> None:
+    """
+    Plot signed distance field with a diverging colormap centered at zero.
+
+    Parameters
+    ----------
+    phi : np.ndarray
+        Signed distance values at cell centres.
+    fname : str
+        Output PNG filename.
+    levels : int, optional
+        Number of contour levels to overlay. Set to ``None`` to skip contours.
+    show : bool, optional
+        If ``True``, display the figure interactively.
+    """
     out_dir = _ensure_output_dir()
     plt.figure()
-    plt.imshow(phi, origin="lower", cmap="coolwarm")
+    max_abs = float(np.nanmax(np.abs(phi)))
+    norm = colors.TwoSlopeNorm(vmin=-max_abs, vcenter=0.0, vmax=max_abs)
+    plt.imshow(phi, origin="lower", cmap="coolwarm", norm=norm)
     if levels:
-        plt.contour(phi, levels=levels, colors="k", linewidths=0.5, origin="lower")
+        plt.contour(phi, levels=levels, colors="k", linewidths=0.5)
     plt.title("Signed distance field φ")
     plt.colorbar()
     plt.tight_layout()
@@ -36,12 +60,13 @@ def plot_phi(phi: np.ndarray, fname: str, levels: Optional[int] = 20, show: bool
         plt.show()
     plt.close()
 
+
 def plot_bouzidi_hist(bouzidi: np.ndarray, fname: str, show: bool = False) -> None:
     """Histogram of Bouzidi q_i values (ignoring NaNs)."""
     out_dir = _ensure_output_dir()
     plt.figure()
     vals = bouzidi[~np.isnan(bouzidi)]
-    plt.hist(vals, bins=50, range=(0,1))
+    plt.hist(vals, bins=50, range=(0, 1))
     plt.title("Bouzidi q_i histogram")
     plt.xlabel("q_i")
     plt.ylabel("Count")
@@ -50,3 +75,30 @@ def plot_bouzidi_hist(bouzidi: np.ndarray, fname: str, show: bool = False) -> No
     if show:
         plt.show()
     plt.close()
+
+
+def plot_bouzidi_dirs(
+    bouzidi: np.ndarray, fname_prefix: str, show: bool = False
+) -> None:
+    """Plot Bouzidi ``q_i`` fields for each direction separately.
+
+    Parameters
+    ----------
+    bouzidi : np.ndarray
+        Array of shape ``(ny, nx, 9)`` containing Bouzidi coefficients.
+    fname_prefix : str
+        Prefix for output PNG files. Images are saved as ``<prefix>_i.png``.
+    show : bool, optional
+        If ``True``, display each figure interactively.
+    """
+    out_dir = _ensure_output_dir()
+    for i in range(9):
+        plt.figure()
+        plt.imshow(bouzidi[:, :, i], origin="lower", cmap="viridis")
+        plt.title(f"Bouzidi q_{i}")
+        plt.colorbar()
+        plt.tight_layout()
+        plt.savefig(os.path.join(out_dir, f"{fname_prefix}_{i}.png"), dpi=150)
+        if show:
+            plt.show()
+        plt.close()

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,18 @@
+import os
+import numpy as np
+
+from lb2dgeom import viz
+
+
+def test_viz_outputs():
+    phi = np.array([[1.0, -1.0], [-0.5, 0.5]], dtype=np.float32)
+    bouzidi = np.zeros((2, 2, 9), dtype=np.float32)
+
+    viz.plot_phi(phi, "phi_test.png", levels=5, show=False)
+    viz.plot_bouzidi_hist(bouzidi, "hist_test.png", show=False)
+    viz.plot_bouzidi_dirs(bouzidi, "dir_test", show=False)
+
+    out_dir = os.path.join("examples", "output")
+    assert os.path.exists(os.path.join(out_dir, "phi_test.png"))
+    assert os.path.exists(os.path.join(out_dir, "hist_test.png"))
+    assert os.path.exists(os.path.join(out_dir, "dir_test_0.png"))


### PR DESCRIPTION
## Summary
- Rewrite README with full feature guide and quickstart example
- Add complete Cassini oval demo and per-direction Bouzidi plotting
- Fix SDF colormap handling and provide Bouzidi direction plots
- Add tests for visualization utilities

## Testing
- `pytest -q`
- `python examples/demo_cassini.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3219e004832092593aa6ae8755fa