### PR TITLE
Disable pickle loading in npz IO

### DIFF
--- a/src/lb2dgeom/io.py
+++ b/src/lb2dgeom/io.py
@@ -1,7 +1,14 @@
 import numpy as np
 from typing import Any, Dict
 
-def save_npz(path: str, solid: np.ndarray, phi: np.ndarray, bouzidi: np.ndarray, **extras: Any) -> None:
+
+def save_npz(
+    path: str,
+    solid: np.ndarray,
+    phi: np.ndarray,
+    bouzidi: np.ndarray,
+    **extras: Any,
+) -> None:
     """
     Save geometry arrays to a compressed .npz file.
 
@@ -21,19 +28,20 @@ def save_npz(path: str, solid: np.ndarray, phi: np.ndarray, bouzidi: np.ndarray,
     np.savez_compressed(path, solid=solid, phi=phi, bouzidi=bouzidi, **extras)
 
 
-def load_npz(path: str) -> Dict[str, Any]:
-    """
-    Load geometry arrays from a compressed .npz file.
+def load_npz(path: str, allow_pickle: bool = False) -> Dict[str, Any]:
+    """Load geometry arrays from a compressed ``.npz`` file.
 
     Parameters
     ----------
     path : str
         File path.
+    allow_pickle : bool, optional
+        Whether to allow loading pickled object arrays. Defaults to ``False``.
 
     Returns
     -------
     data : dict
-        Dictionary with 'solid', 'phi', 'bouzidi', and any extra keys.
+        Dictionary with ``'solid'``, ``'phi'``, ``'bouzidi'``, and any extra keys.
     """
-    with np.load(path, allow_pickle=True) as data:
+    with np.load(path, allow_pickle=allow_pickle) as data:
         return {key: data[key] for key in data.files}

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from lb2dgeom.io import load_npz, save_npz
+
+
+def test_save_load_npz(tmp_path):
+    solid = np.array([[0, 1], [1, 0]], dtype=np.uint8)
+    phi = np.array([[1.0, -1.0], [-0.5, 0.5]], dtype=np.float32)
+    bouzidi = np.zeros((2, 2, 9), dtype=np.float32)
+    extra = np.array([1, 2, 3], dtype=np.float32)
+
+    path = tmp_path / "geom.npz"
+    save_npz(path, solid, phi, bouzidi, extra=extra)
+
+    data = load_npz(path)
+    assert np.array_equal(data["solid"], solid)
+    assert np.array_equal(data["phi"], phi)
+    assert np.array_equal(data["bouzidi"], bouzidi)
+    assert np.array_equal(data["extra"], extra)


### PR DESCRIPTION
## Summary
- default `load_npz` to disallow pickle and add an `allow_pickle` flag for advanced use
- add regression test ensuring `save_npz` and `load_npz` round-trip data without pickling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f378081e48320954a4fb125f0dea3