### PR TITLE
Handle NaNs in Bouzidi interpolation

### DIFF
--- a/src/lb2dgeom/bouzidi.py
+++ b/src/lb2dgeom/bouzidi.py
@@ -63,17 +63,23 @@ def compute_bouzidi(
                     continue
                 s0 = 0.0
                 s1 = L
+                encountered_nan = False
                 for _ in range(max_iter):
                     sm = 0.5 * (s0 + s1)
                     xm = xf + (ex / E_LENGTHS[i]) * sm
                     ym = yf + (ey / E_LENGTHS[i]) * sm
                     phi_m = float(interp_phi(xm, ym, grid, phi))
+                    if np.isnan(phi_m):
+                        encountered_nan = True
+                        break
                     if phi_m > 0:
                         s0 = sm
                     else:
                         s1 = sm
                     if abs(s1 - s0) < tol * dx:
                         break
+                if encountered_nan:
+                    continue
                 d_wall = s1
                 q_i = d_wall / L
                 bouzidi[y, x, i] = q_i

--- a/tests/test_raster_bouzidi.py
+++ b/tests/test_raster_bouzidi.py
@@ -40,3 +40,24 @@ def test_bouzidi_handles_boundary_on_neighbor_center():
     y = int(0 - g.origin[1])
     x = int(6 - g.origin[0])  # Fluid cell at (6, 0)
     assert np.isclose(bouzidi[y, x, 3], 1.0)
+
+
+def test_bouzidi_skips_out_of_bounds_interp():
+    g = Grid(3, 3, dx=1.0, origin=(0.0, 0.0))
+    phi = np.array(
+        [
+            [1.0, 1.0, -1.0],
+            [1.0, 1.0, -1.0],
+            [1.0, 1.0, np.nan],
+        ]
+    )
+    solid = np.array(
+        [
+            [0, 0, 1],
+            [0, 0, 1],
+            [0, 0, 1],
+        ],
+        dtype=int,
+    )
+    bouzidi = compute_bouzidi(g, phi, solid)
+    assert np.isnan(bouzidi[1, 1, 1])


### PR DESCRIPTION
## Summary
- skip Bouzidi bracket updates when interpolated phi is NaN to avoid invalid q_i
- test Bouzidi interpolation outside grid leaves q_i as NaN

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f378171408320a54437000f69b67e