### PR TITLE
docs: add boolean operations example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@ Bouzidi link-fraction calculations for the D2Q9 model.
 **lb2dgeom** covers the entire workflow of preparing complex 2‑D boundaries for
 LBM solvers:
 
-* **Parametric shapes** – circle, ellipse, rectangle (axis aligned or rotated),
+- **Parametric shapes** – circle, ellipse, rectangle (axis aligned or rotated),
   rounded rectangle and Cassini oval.
-* **Boolean operations** – union, intersection and difference are implemented
+- **Boolean operations** – union, intersection and difference are implemented
   using standard signed–distance blending rules.
-* **Signed distance fields** – shapes provide analytic ``sdf(x, y)`` methods and
+- **Signed distance fields** – shapes provide analytic `sdf(x, y)` methods and
   are rasterised onto uniform Cartesian grids.
-* **Bouzidi boundary fractions** – compute ``q_i`` link fractions for all
+- **Bouzidi boundary fractions** – compute `q_i` link fractions for all
   D2Q9 lattice directions with physical length normalisation.
-* **I/O helpers** – save and load geometry data sets in ``.npz`` format.
-* **Visualisation utilities** – plot solid masks, signed distance fields,
-  Bouzidi histograms and per‑direction ``q_i`` fields.
+- **I/O helpers** – save and load geometry data sets in `.npz` format.
+- **Visualisation utilities** – plot solid masks, signed distance fields,
+  Bouzidi histograms and per‑direction `q_i` fields.
 
 ## Installation
 
 ### Conda environment
 
-Create and activate the conda environment specified in ``environment.yml``:
+Create and activate the conda environment specified in `environment.yml`:
 
 ```bash
 conda env create -f environment.yml
@@ -69,27 +69,53 @@ viz.plot_phi(phi, "circle_phi.png")
 viz.plot_bouzidi_dirs(bouzidi, "circle_bouzidi_dir")
 ```
 
-See the ``examples/`` directory for complete scripts for an ellipse and a
-Cassini oval. Running an example (e.g. ``python examples/demo_cassini.py``)
-produces geometry files and PNG diagnostics in ``examples/output/``.
+See the `examples/` directory for complete scripts for an ellipse and a
+Cassini oval. Running an example (e.g. `python examples/demo_cassini.py`)
+produces geometry files and PNG diagnostics in `examples/output/`.
 
 ### Feature guide
 
-* **Grid generation** – ``Grid(nx, ny, dx, origin)`` provides cell centres and
+- **Grid generation** – `Grid(nx, ny, dx, origin)` provides cell centres and
   spacing in physical units.
-* **Shapes** – analytic ``sdf`` implementations live in ``lb2dgeom.shapes`` and
-  share a common ``Shape`` base class. Shapes may be combined via boolean
-  operations from ``lb2dgeom.shapes.ops``.
-* **Rasterisation** – ``rasterize(grid, shape)`` samples ``phi`` and returns the
+- **Shapes** – analytic `sdf` implementations live in `lb2dgeom.shapes` and
+  share a common `Shape` base class. Shapes may be combined via boolean
+  operations from `lb2dgeom.shapes.ops`.
+- **Rasterisation** – `rasterize(grid, shape)` samples `phi` and returns the
   solid mask for LBM nodes.
-* **Bouzidi coefficients** – ``compute_bouzidi`` locates boundary intersections
-  for all lattice directions and returns an array of ``q_i`` fractions with
-  ``NaN`` in cells without solid neighbours.
-* **I/O** – ``lb2dgeom.io.save_npz`` and ``load_npz`` persist geometry arrays to
+- **Bouzidi coefficients** – `compute_bouzidi` locates boundary intersections
+  for all lattice directions and returns an array of `q_i` fractions with
+  `NaN` in cells without solid neighbours.
+- **I/O** – `lb2dgeom.io.save_npz` and `load_npz` persist geometry arrays to
   disk.
-* **Visualisation** – ``lb2dgeom.viz`` contains
-  ``plot_solid``, ``plot_phi``, ``plot_bouzidi_hist`` and
-  ``plot_bouzidi_dirs`` for inspecting geometry and boundary data.
+- **Visualisation** – `lb2dgeom.viz` contains
+  `plot_solid`, `plot_phi`, `plot_bouzidi_hist` and
+  `plot_bouzidi_dirs` for inspecting geometry and boundary data.
+
+### Boolean operations
+
+The `lb2dgeom.shapes.ops` module provides `union`, `difference` and
+`intersection` helpers for combining shapes. The snippet below joins a circle
+and rectangle and renders the union mask:
+
+```python
+from lb2dgeom.grids import Grid
+from lb2dgeom.raster import rasterize
+from lb2dgeom.shapes.circle import Circle
+from lb2dgeom.shapes.ops import difference, intersection, union
+from lb2dgeom.shapes.rectangle import Rectangle
+from lb2dgeom import viz
+
+circle = Circle(x0=-10.0, y0=0.0, r=15.0)
+rect = Rectangle(x0=10.0, y0=0.0, w=20.0, h=30.0)
+
+u = union(circle, rect)
+i = intersection(circle, rect)
+d = difference(circle, rect)
+
+g = Grid(nx=120, ny=80, dx=1.0, origin=(-60.0, -40.0))
+phi_u, solid_u = rasterize(g, u)
+viz.plot_solid(solid_u, "union.png")
+```
 
 ## Running tests
 
@@ -102,4 +128,3 @@ pytest -q
 ## License
 
 This project is released under the MIT License.
-


### PR DESCRIPTION
## Summary
- document union/difference/intersection utilities in README
- show sample code combining two shapes and plotting the union

## Testing
- `mdformat --check README.md`
- `python - <<'PY'
import pathlib
p=pathlib.Path('README.md')
viol=[(i,len(l)) for i,l in enumerate(p.read_text().splitlines(),1) if len(l)>88]
print(viol)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3b9ef78c832085be9d04584c454e