### PR TITLE
Add configurable output directory for viz functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,8 @@ The library’s goal is to provide high-accuracy signed distance field (SDF) gen
 * **Grid agent** must provide coordinates in *physical* units for SDF evaluation.
 * **Shape agents** must treat negative φ as inside solid.
 * **Bouzidi agent** assumes φ is continuous; SDF discontinuities will break root-finding.
-* **Viz agent** saves plots to `examples/output/` regardless of environment, shows interactively only in `__main__`.
+* **Viz agent** writes plots to a specified `out_dir` (defaulting to the current
+  working directory) and shows interactively only in `__main__`.
 * **I/O agent** should always save `solid`, `phi`, `bouzidi` arrays with matching dimensions.
 
 ---

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ viz.plot_bouzidi_dirs(bouzidi, "circle_bouzidi_dir")
 
 See the ``examples/`` directory for complete scripts for an ellipse and a
 Cassini oval. Running an example (e.g. ``python examples/demo_cassini.py``)
-produces geometry files and PNG diagnostics in ``examples/output/``.
+produces geometry files and PNG diagnostics in ``examples/output/``, which
+is supplied via the ``out_dir`` parameter in each plotting call.
 
 ### Feature guide
 
@@ -89,7 +90,9 @@ produces geometry files and PNG diagnostics in ``examples/output/``.
   disk.
 * **Visualisation** – ``lb2dgeom.viz`` contains
   ``plot_solid``, ``plot_phi``, ``plot_bouzidi_hist`` and
-  ``plot_bouzidi_dirs`` for inspecting geometry and boundary data.
+  ``plot_bouzidi_dirs`` for inspecting geometry and boundary data. Each
+  plotting function accepts an optional ``out_dir`` argument, defaulting to
+  the current working directory.
 
 ## Running tests
 

--- a/examples/demo_cassini.py
+++ b/examples/demo_cassini.py
@@ -30,9 +30,11 @@ if __name__ == "__main__":
     save_npz(os.path.join(out_dir, "cassini_geom.npz"), solid, phi, bouzidi)
 
     # Diagnostics
-    viz.plot_solid(solid, "cassini_solid.png", show=False)
-    viz.plot_phi(phi, "cassini_phi.png", levels=30, show=False)
-    viz.plot_bouzidi_hist(bouzidi, "cassini_bouzidi_hist.png", show=False)
-    viz.plot_bouzidi_dirs(bouzidi, "cassini_bouzidi_dir", show=False)
+    viz.plot_solid(solid, "cassini_solid.png", out_dir=out_dir, show=False)
+    viz.plot_phi(phi, "cassini_phi.png", levels=30, out_dir=out_dir, show=False)
+    viz.plot_bouzidi_hist(
+        bouzidi, "cassini_bouzidi_hist.png", out_dir=out_dir, show=False
+    )
+    viz.plot_bouzidi_dirs(bouzidi, "cassini_bouzidi_dir", out_dir=out_dir, show=False)
 
     print("Demo Cassini oval complete. Outputs saved in examples/output/")

--- a/examples/demo_ellipse.py
+++ b/examples/demo_ellipse.py
@@ -26,8 +26,10 @@ if __name__ == "__main__":
     save_npz(os.path.join(out_dir, "ellipse_geom.npz"), solid, phi, bouzidi)
 
     # Diagnostics
-    viz.plot_solid(solid, "ellipse_solid.png", show=False)
-    viz.plot_phi(phi, "ellipse_phi.png", levels=30, show=False)
-    viz.plot_bouzidi_hist(bouzidi, "ellipse_bouzidi_hist.png", show=False)
+    viz.plot_solid(solid, "ellipse_solid.png", out_dir=out_dir, show=False)
+    viz.plot_phi(phi, "ellipse_phi.png", levels=30, out_dir=out_dir, show=False)
+    viz.plot_bouzidi_hist(
+        bouzidi, "ellipse_bouzidi_hist.png", out_dir=out_dir, show=False
+    )
 
     print("Demo ellipse complete. Outputs saved in examples/output/")

--- a/src/lb2dgeom/viz.py
+++ b/src/lb2dgeom/viz.py
@@ -8,15 +8,31 @@ import numpy as np
 from matplotlib import colors
 
 
-def _ensure_output_dir():
-    out_dir = os.path.join("examples", "output")
+def _ensure_output_dir(out_dir: Optional[str] = None) -> str:
+    """Return a directory for outputs, creating it if necessary."""
+    if out_dir is None:
+        out_dir = os.curdir
     os.makedirs(out_dir, exist_ok=True)
     return out_dir
 
 
-def plot_solid(solid: np.ndarray, fname: str, show: bool = False) -> None:
-    """Plot solid mask."""
-    out_dir = _ensure_output_dir()
+def plot_solid(
+    solid: np.ndarray, fname: str, out_dir: Optional[str] = None, show: bool = False
+) -> None:
+    """Plot solid mask.
+
+    Parameters
+    ----------
+    solid : np.ndarray
+        Binary solid mask.
+    fname : str
+        Output PNG filename.
+    out_dir : str, optional
+        Directory for output file. Defaults to the current working directory.
+    show : bool, optional
+        If ``True``, display the figure interactively.
+    """
+    out_dir = _ensure_output_dir(out_dir)
     plt.figure()
     plt.imshow(solid, origin="lower", cmap="gray_r")
     plt.title("Solid mask")
@@ -29,7 +45,11 @@ def plot_solid(solid: np.ndarray, fname: str, show: bool = False) -> None:
 
 
 def plot_phi(
-    phi: np.ndarray, fname: str, levels: Optional[int] = 20, show: bool = False
+    phi: np.ndarray,
+    fname: str,
+    levels: Optional[int] = 20,
+    out_dir: Optional[str] = None,
+    show: bool = False,
 ) -> None:
     """
     Plot signed distance field with a diverging colormap centered at zero.
@@ -42,10 +62,12 @@ def plot_phi(
         Output PNG filename.
     levels : int, optional
         Number of contour levels to overlay. Set to ``None`` to skip contours.
+    out_dir : str, optional
+        Directory for output file. Defaults to the current working directory.
     show : bool, optional
         If ``True``, display the figure interactively.
     """
-    out_dir = _ensure_output_dir()
+    out_dir = _ensure_output_dir(out_dir)
     plt.figure()
     max_abs = float(np.nanmax(np.abs(phi)))
     norm = colors.TwoSlopeNorm(vmin=-max_abs, vcenter=0.0, vmax=max_abs)
@@ -61,9 +83,23 @@ def plot_phi(
     plt.close()
 
 
-def plot_bouzidi_hist(bouzidi: np.ndarray, fname: str, show: bool = False) -> None:
-    """Histogram of Bouzidi q_i values (ignoring NaNs)."""
-    out_dir = _ensure_output_dir()
+def plot_bouzidi_hist(
+    bouzidi: np.ndarray, fname: str, out_dir: Optional[str] = None, show: bool = False
+) -> None:
+    """Histogram of Bouzidi q_i values (ignoring NaNs).
+
+    Parameters
+    ----------
+    bouzidi : np.ndarray
+        Bouzidi coefficients.
+    fname : str
+        Output PNG filename.
+    out_dir : str, optional
+        Directory for output file. Defaults to the current working directory.
+    show : bool, optional
+        If ``True``, display the figure interactively.
+    """
+    out_dir = _ensure_output_dir(out_dir)
     plt.figure()
     vals = bouzidi[~np.isnan(bouzidi)]
     plt.hist(vals, bins=50, range=(0, 1))
@@ -78,7 +114,10 @@ def plot_bouzidi_hist(bouzidi: np.ndarray, fname: str, show: bool = False) -> No
 
 
 def plot_bouzidi_dirs(
-    bouzidi: np.ndarray, fname_prefix: str, show: bool = False
+    bouzidi: np.ndarray,
+    fname_prefix: str,
+    out_dir: Optional[str] = None,
+    show: bool = False,
 ) -> None:
     """Plot Bouzidi ``q_i`` fields for each direction separately.
 
@@ -88,10 +127,12 @@ def plot_bouzidi_dirs(
         Array of shape ``(ny, nx, 9)`` containing Bouzidi coefficients.
     fname_prefix : str
         Prefix for output PNG files. Images are saved as ``<prefix>_i.png``.
+    out_dir : str, optional
+        Directory for output files. Defaults to the current working directory.
     show : bool, optional
         If ``True``, display each figure interactively.
     """
-    out_dir = _ensure_output_dir()
+    out_dir = _ensure_output_dir(out_dir)
     for i in range(9):
         plt.figure()
         plt.imshow(bouzidi[:, :, i], origin="lower", cmap="viridis")

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,18 +1,16 @@
-import os
 import numpy as np
 
 from lb2dgeom import viz
 
 
-def test_viz_outputs():
+def test_viz_outputs(tmp_path):
     phi = np.array([[1.0, -1.0], [-0.5, 0.5]], dtype=np.float32)
     bouzidi = np.zeros((2, 2, 9), dtype=np.float32)
 
-    viz.plot_phi(phi, "phi_test.png", levels=5, show=False)
-    viz.plot_bouzidi_hist(bouzidi, "hist_test.png", show=False)
-    viz.plot_bouzidi_dirs(bouzidi, "dir_test", show=False)
+    viz.plot_phi(phi, "phi_test.png", levels=5, out_dir=tmp_path, show=False)
+    viz.plot_bouzidi_hist(bouzidi, "hist_test.png", out_dir=tmp_path, show=False)
+    viz.plot_bouzidi_dirs(bouzidi, "dir_test", out_dir=tmp_path, show=False)
 
-    out_dir = os.path.join("examples", "output")
-    assert os.path.exists(os.path.join(out_dir, "phi_test.png"))
-    assert os.path.exists(os.path.join(out_dir, "hist_test.png"))
-    assert os.path.exists(os.path.join(out_dir, "dir_test_0.png"))
+    assert (tmp_path / "phi_test.png").exists()
+    assert (tmp_path / "hist_test.png").exists()
+    assert (tmp_path / "dir_test_0.png").exists()


### PR DESCRIPTION
## Summary
- allow passing an optional `out_dir` to `_ensure_output_dir` and all plotting helpers
- route example scripts' plots to `examples/output`
- document new `out_dir` usage and update agent guide and tests

## Testing
- `black examples/demo_cassini.py examples/demo_ellipse.py src/lb2dgeom/viz.py`
- `pytest -q`
- `python examples/demo_ellipse.py`
- `python examples/demo_cassini.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3bc6970883208c5e45e2ae30a1cc