### PR TITLE
feat: top-level API re-exports

### DIFF
--- a/src/lb2dgeom/__init__.py
+++ b/src/lb2dgeom/__init__.py
@@ -1,1 +1,21 @@
-# Package initializer
+"""Convenience re-exports for :mod:`lb2dgeom`.
+
+This module exposes the most commonly used classes, functions and
+subpackages at the top level for easy access.  Users can simply import
+``lb2dgeom`` and access :class:`Grid`, :func:`rasterize`,
+:func:`compute_bouzidi`, as well as the :mod:`viz` and :mod:`shapes`
+subpackages without needing to traverse the package hierarchy.
+"""
+
+from . import shapes, viz
+from .bouzidi import compute_bouzidi
+from .grids import Grid
+from .raster import rasterize
+
+__all__ = [
+    "Grid",
+    "rasterize",
+    "compute_bouzidi",
+    "viz",
+    "shapes",
+]


### PR DESCRIPTION
## Summary
- expose Grid, rasterize, compute_bouzidi, viz, and shapes at package root
- document convenience re-exports in module docstring

## Testing
- `python -m flake8 src/lb2dgeom/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3bcbaf9c8320b9d1d54ad6fd2455