### PR TITLE
feat: make visualization output directory configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,10 @@ The library’s goal is to provide high-accuracy signed distance field (SDF) gen
 * **Grid agent** must provide coordinates in *physical* units for SDF evaluation.
 * **Shape agents** must treat negative φ as inside solid.
 * **Bouzidi agent** assumes φ is continuous; SDF discontinuities will break root-finding.
-* **Viz agent** saves plots to `examples/output/` regardless of environment, shows interactively only in `__main__`.
+* **Viz agent** writes plots to a caller-specified directory (default is the
+  current working directory). Example scripts pass
+  `out_dir=os.path.join("examples", "output")` and show plots interactively
+  only in `__main__`.
 * **I/O agent** should always save `solid`, `phi`, `bouzidi` arrays with matching dimensions.
 
 ---

--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ viz.plot_bouzidi_dirs(bouzidi, "circle_bouzidi_dir")
 ```
 
 See the ``examples/`` directory for complete scripts for an ellipse, a Cassini
-oval, and boolean operations on primitives. Running an example (e.g. ``python
-examples/demo_boolean_ops.py``) produces geometry files and PNG diagnostics in
-``examples/output/``.
+oval, and boolean operations on primitives. Running an example (e.g.
+``python examples/demo_boolean_ops.py``) produces geometry files and PNG
+diagnostics. Each script writes its images to ``examples/output/`` by
+supplying ``out_dir=os.path.join("examples", "output")`` to the plotting
+utilities.
 
 ### Feature guide
 

--- a/examples/demo_boolean_ops.py
+++ b/examples/demo_boolean_ops.py
@@ -34,10 +34,14 @@ if __name__ == "__main__":
     save_npz(os.path.join(out_dir, "boolean_union_geom.npz"), solid_u, phi_u, bouzidi_u)
 
     # Diagnostics for union
-    viz.plot_solid(solid_u, "boolean_union_solid.png", show=False)
-    viz.plot_phi(phi_u, "boolean_union_phi.png", levels=30, show=False)
-    viz.plot_bouzidi_hist(bouzidi_u, "boolean_union_bouzidi_hist.png", show=False)
-    viz.plot_bouzidi_dirs(bouzidi_u, "boolean_union_bouzidi_dir", show=False)
+    viz.plot_solid(solid_u, "boolean_union_solid.png", show=False, out_dir=out_dir)
+    viz.plot_phi(phi_u, "boolean_union_phi.png", levels=30, show=False, out_dir=out_dir)
+    viz.plot_bouzidi_hist(
+        bouzidi_u, "boolean_union_bouzidi_hist.png", show=False, out_dir=out_dir
+    )
+    viz.plot_bouzidi_dirs(
+        bouzidi_u, "boolean_union_bouzidi_dir", show=False, out_dir=out_dir
+    )
 
     # --- Difference: circle minus rectangle ---
     circle_d = Circle(x0=0.0, y0=0.0, r=25.0)
@@ -54,9 +58,13 @@ if __name__ == "__main__":
     save_npz(os.path.join(out_dir, "boolean_diff_geom.npz"), solid_d, phi_d, bouzidi_d)
 
     # Diagnostics for difference
-    viz.plot_solid(solid_d, "boolean_diff_solid.png", show=False)
-    viz.plot_phi(phi_d, "boolean_diff_phi.png", levels=30, show=False)
-    viz.plot_bouzidi_hist(bouzidi_d, "boolean_diff_bouzidi_hist.png", show=False)
-    viz.plot_bouzidi_dirs(bouzidi_d, "boolean_diff_bouzidi_dir", show=False)
+    viz.plot_solid(solid_d, "boolean_diff_solid.png", show=False, out_dir=out_dir)
+    viz.plot_phi(phi_d, "boolean_diff_phi.png", levels=30, show=False, out_dir=out_dir)
+    viz.plot_bouzidi_hist(
+        bouzidi_d, "boolean_diff_bouzidi_hist.png", show=False, out_dir=out_dir
+    )
+    viz.plot_bouzidi_dirs(
+        bouzidi_d, "boolean_diff_bouzidi_dir", show=False, out_dir=out_dir
+    )
 
     print("Boolean ops demo complete. Outputs saved in examples/output/")

--- a/examples/demo_cassini.py
+++ b/examples/demo_cassini.py
@@ -30,9 +30,11 @@ if __name__ == "__main__":
     save_npz(os.path.join(out_dir, "cassini_geom.npz"), solid, phi, bouzidi)
 
     # Diagnostics
-    viz.plot_solid(solid, "cassini_solid.png", show=False)
-    viz.plot_phi(phi, "cassini_phi.png", levels=30, show=False)
-    viz.plot_bouzidi_hist(bouzidi, "cassini_bouzidi_hist.png", show=False)
-    viz.plot_bouzidi_dirs(bouzidi, "cassini_bouzidi_dir", show=False)
+    viz.plot_solid(solid, "cassini_solid.png", show=False, out_dir=out_dir)
+    viz.plot_phi(phi, "cassini_phi.png", levels=30, show=False, out_dir=out_dir)
+    viz.plot_bouzidi_hist(
+        bouzidi, "cassini_bouzidi_hist.png", show=False, out_dir=out_dir
+    )
+    viz.plot_bouzidi_dirs(bouzidi, "cassini_bouzidi_dir", show=False, out_dir=out_dir)
 
     print("Demo Cassini oval complete. Outputs saved in examples/output/")

--- a/examples/demo_ellipse.py
+++ b/examples/demo_ellipse.py
@@ -26,8 +26,10 @@ if __name__ == "__main__":
     save_npz(os.path.join(out_dir, "ellipse_geom.npz"), solid, phi, bouzidi)
 
     # Diagnostics
-    viz.plot_solid(solid, "ellipse_solid.png", show=False)
-    viz.plot_phi(phi, "ellipse_phi.png", levels=30, show=False)
-    viz.plot_bouzidi_hist(bouzidi, "ellipse_bouzidi_hist.png", show=False)
+    viz.plot_solid(solid, "ellipse_solid.png", show=False, out_dir=out_dir)
+    viz.plot_phi(phi, "ellipse_phi.png", levels=30, show=False, out_dir=out_dir)
+    viz.plot_bouzidi_hist(
+        bouzidi, "ellipse_bouzidi_hist.png", show=False, out_dir=out_dir
+    )
 
     print("Demo ellipse complete. Outputs saved in examples/output/")

--- a/src/lb2dgeom/viz.py
+++ b/src/lb2dgeom/viz.py
@@ -8,13 +8,32 @@ import numpy as np
 from matplotlib import colors
 
 
-def _ensure_output_dir():
-    out_dir = os.path.join("examples", "output")
+def _ensure_output_dir(out_dir: Optional[str] = None) -> str:
+    """Return a directory path for plot outputs, creating it if needed.
+
+    Parameters
+    ----------
+    out_dir : str, optional
+        Target directory for output images. If ``None``, the current working
+        directory is used.
+
+    Returns
+    -------
+    str
+        Absolute path to the output directory.
+    """
+    if out_dir is None:
+        out_dir = os.getcwd()
     os.makedirs(out_dir, exist_ok=True)
     return out_dir
 
 
-def plot_solid(solid: np.ndarray, fname: str, show: bool = False) -> None:
+def plot_solid(
+    solid: np.ndarray,
+    fname: str,
+    show: bool = False,
+    out_dir: Optional[str] = None,
+) -> None:
     """Plot a binary solid mask.
 
     Parameters
@@ -25,12 +44,15 @@ def plot_solid(solid: np.ndarray, fname: str, show: bool = False) -> None:
         Output PNG filename.
     show : bool, optional
         If ``True``, display the figure interactively.
+    out_dir : str, optional
+        Directory to save the output image. Defaults to the current working
+        directory.
 
     Returns
     -------
     None
     """
-    out_dir = _ensure_output_dir()
+    out_dir = _ensure_output_dir(out_dir)
     plt.figure()
     plt.imshow(solid, origin="lower", cmap="gray_r")
     plt.title("Solid mask")
@@ -43,7 +65,11 @@ def plot_solid(solid: np.ndarray, fname: str, show: bool = False) -> None:
 
 
 def plot_phi(
-    phi: np.ndarray, fname: str, levels: Optional[int] = 20, show: bool = False
+    phi: np.ndarray,
+    fname: str,
+    levels: Optional[int] = 20,
+    show: bool = False,
+    out_dir: Optional[str] = None,
 ) -> None:
     """
     Plot signed distance field with a diverging colormap centered at zero.
@@ -58,8 +84,11 @@ def plot_phi(
         Number of contour levels to overlay. Set to ``None`` to skip contours.
     show : bool, optional
         If ``True``, display the figure interactively.
+    out_dir : str, optional
+        Directory to save the output image. Defaults to the current working
+        directory.
     """
-    out_dir = _ensure_output_dir()
+    out_dir = _ensure_output_dir(out_dir)
     plt.figure()
     max_abs = float(np.nanmax(np.abs(phi)))
     norm = colors.TwoSlopeNorm(vmin=-max_abs, vcenter=0.0, vmax=max_abs)
@@ -75,7 +104,12 @@ def plot_phi(
     plt.close()
 
 
-def plot_bouzidi_hist(bouzidi: np.ndarray, fname: str, show: bool = False) -> None:
+def plot_bouzidi_hist(
+    bouzidi: np.ndarray,
+    fname: str,
+    show: bool = False,
+    out_dir: Optional[str] = None,
+) -> None:
     """Plot a histogram of Bouzidi ``q_i`` values.
 
     Parameters
@@ -86,12 +120,15 @@ def plot_bouzidi_hist(bouzidi: np.ndarray, fname: str, show: bool = False) -> No
         Output PNG filename.
     show : bool, optional
         If ``True``, display the figure interactively.
+    out_dir : str, optional
+        Directory to save the output image. Defaults to the current working
+        directory.
 
     Returns
     -------
     None
     """
-    out_dir = _ensure_output_dir()
+    out_dir = _ensure_output_dir(out_dir)
     plt.figure()
     vals = bouzidi[~np.isnan(bouzidi)]
     plt.hist(vals, bins=50, range=(0, 1))
@@ -106,7 +143,10 @@ def plot_bouzidi_hist(bouzidi: np.ndarray, fname: str, show: bool = False) -> No
 
 
 def plot_bouzidi_dirs(
-    bouzidi: np.ndarray, fname_prefix: str, show: bool = False
+    bouzidi: np.ndarray,
+    fname_prefix: str,
+    show: bool = False,
+    out_dir: Optional[str] = None,
 ) -> None:
     """Plot Bouzidi ``q_i`` fields for each direction separately.
 
@@ -118,8 +158,11 @@ def plot_bouzidi_dirs(
         Prefix for output PNG files. Images are saved as ``<prefix>_i.png``.
     show : bool, optional
         If ``True``, display each figure interactively.
+    out_dir : str, optional
+        Directory to save the output images. Defaults to the current working
+        directory.
     """
-    out_dir = _ensure_output_dir()
+    out_dir = _ensure_output_dir(out_dir)
     for i in range(9):
         plt.figure()
         plt.imshow(bouzidi[:, :, i], origin="lower", cmap="viridis")

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,18 +1,16 @@
-import os
 import numpy as np
 
 from lb2dgeom import viz
 
 
-def test_viz_outputs():
+def test_viz_outputs(tmp_path):
     phi = np.array([[1.0, -1.0], [-0.5, 0.5]], dtype=np.float32)
     bouzidi = np.zeros((2, 2, 9), dtype=np.float32)
 
-    viz.plot_phi(phi, "phi_test.png", levels=5, show=False)
-    viz.plot_bouzidi_hist(bouzidi, "hist_test.png", show=False)
-    viz.plot_bouzidi_dirs(bouzidi, "dir_test", show=False)
+    viz.plot_phi(phi, "phi_test.png", levels=5, show=False, out_dir=tmp_path)
+    viz.plot_bouzidi_hist(bouzidi, "hist_test.png", show=False, out_dir=tmp_path)
+    viz.plot_bouzidi_dirs(bouzidi, "dir_test", show=False, out_dir=tmp_path)
 
-    out_dir = os.path.join("examples", "output")
-    assert os.path.exists(os.path.join(out_dir, "phi_test.png"))
-    assert os.path.exists(os.path.join(out_dir, "hist_test.png"))
-    assert os.path.exists(os.path.join(out_dir, "dir_test_0.png"))
+    assert (tmp_path / "phi_test.png").exists()
+    assert (tmp_path / "hist_test.png").exists()
+    assert (tmp_path / "dir_test_0.png").exists()


### PR DESCRIPTION
## Summary
- allow specifying the directory for viz outputs through `_ensure_output_dir` and plotting helpers
- forward `out_dir` from examples and tests
- document configurable output path and update agent guidelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4136ab948320808d53037d38628d