### PR TITLE
Fix CassiniOval scalar SDF handling

### DIFF
--- a/src/lb2dgeom/shapes/cassini_oval.py
+++ b/src/lb2dgeom/shapes/cassini_oval.py
@@ -72,7 +72,9 @@ class CassiniOval(Shape):
         )
         sign = np.sign(initial)
 
-        if np.isscalar(dist):
+        if dist.ndim == 0:
+            dist = float(dist)
+            sign = float(sign)
             if dist == 0.0:
                 if sign < 0 and self.a > self.c:
                     dist = np.sqrt(self.a**2 - self.c**2)


### PR DESCRIPTION
## Summary
- Correct CassiniOval.sdf scalar handling by checking `dist.ndim == 0` and casting scalar values
- Apply boundary adjustments for scalar distances similar to array path

## Testing
- `pytest tests/test_shapes.py::test_cassini_oval_sdf_one_loop_two_loop tests/test_shapes.py::test_cassini_oval_gradient_near_boundary -q`

------
https://chatgpt.com/codex/tasks/task_e_689f46760fe48320b487df8b1082d644