### PR TITLE
Handle boundary equality in Bouzidi bracket check

### DIFF
--- a/src/lb2dgeom/bouzidi.py
+++ b/src/lb2dgeom/bouzidi.py
@@ -58,8 +58,17 @@ def compute_bouzidi(
                 yf = Yc[y, x]
                 phi_f = phi[y, x]
                 phi_b = phi[nyn, nxn]
-                # Ensure bracket: fluid positive, solid negative
-                if phi_f < 0 or phi_b > 0:
+                # Ensure bracket: fluid strictly positive, solid strictly negative
+                if (
+                    phi_f <= 0
+                    or phi_b >= 0
+                    or np.isclose(phi_f, 0.0, atol=tol)
+                    or np.isclose(phi_b, 0.0, atol=tol)
+                ):
+                    if np.isclose(phi_f, 0.0, atol=tol) and phi_b < 0:
+                        bouzidi[y, x, i] = 0.0
+                    elif np.isclose(phi_b, 0.0, atol=tol) and phi_f > 0:
+                        bouzidi[y, x, i] = 1.0
                     continue
                 s0 = 0.0
                 s1 = L


### PR DESCRIPTION
## Summary
- treat near-zero signed distances as boundary when computing Bouzidi link fractions
- assign q_i=0 or 1 when boundary lies exactly on fluid or neighbor cell center

## Testing
- `pytest tests/test_raster_bouzidi.py::test_bouzidi_handles_boundary_on_neighbor_center -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f46879e748320865390cedbb15f38